### PR TITLE
Fixed SDP

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.1.0'
+        classpath 'com.android.tools.build:gradle:2.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -28,8 +28,8 @@ android {
 }
 
 dependencies {
-//    Uncomment to use local version
-//    compile files(System.getProperty("user.home") + '/cerbero/dist/android_armv7/lib/jni/openwebrtc.jar')
+    // Uncomment to use local version
+    //compile files(System.getProperty("user.home") + '/cerbero/dist/android_armv7/lib/jni/openwebrtc.jar')
     compile 'io.openwebrtc:openwebrtc-android:0.3'
     compile 'org.mozilla:rhino:1.7R4'
 }

--- a/sdk/src/main/java/com/ericsson/research/owr/sdk/RtcCandidateImpl.java
+++ b/sdk/src/main/java/com/ericsson/research/owr/sdk/RtcCandidateImpl.java
@@ -124,7 +124,7 @@ class RtcCandidateImpl implements RtcCandidate {
 
     @Override
     public int getPort() {
-        return mPort;
+        return (mTransportType == TransportType.TCP_ACTIVE && mPort == 0 ? 9 : mPort);
     }
 
     @Override
@@ -139,7 +139,7 @@ class RtcCandidateImpl implements RtcCandidate {
 
     @Override
     public int getRelatedPort() {
-        return mRelatedPort;
+        return (mRelatedPort > 0 ? mRelatedPort : getPort());
     }
 
     static RtcCandidateImpl fromOwrCandidate(Candidate candidate) {

--- a/sdk/src/main/java/com/ericsson/research/owr/sdk/RtcConfigs.java
+++ b/sdk/src/main/java/com/ericsson/research/owr/sdk/RtcConfigs.java
@@ -48,16 +48,15 @@ public class RtcConfigs {
     }
 
     private static class Default extends RtcConfig {
-        private static final List<RtcPayload> sDefaultVideoPayloads = new ArrayList<>(3);
+        private static final List<RtcPayload> sDefaultVideoPayloads = new ArrayList<>(4);
         static {
             sDefaultVideoPayloads.add(new RtcPayloadImpl(103, "H264", 90000, new HashMap<String, Object>(){{
                 put("packetization-mode", 1);
             }}, 0, false, true, true));
-//            FIXME: Enable when Chrome can handle an offer with RTX for H264
-/*            sDefaultVideoPayloads.add(new PlainRtcPayload(123, "RTX", 90000, new HashMap<String, Object>(){{
+            sDefaultVideoPayloads.add(new RtcPayloadImpl(123, "RTX", 90000, new HashMap<String, Object>(){{
                 put("apt", 103);
                 put("rtx-time", 200);
-            }}, 0, false, false, false));*/
+            }}, 0, false, false, false));
             sDefaultVideoPayloads.add(new RtcPayloadImpl(100, "VP8", 90000, null, 0, true, true, true));
             sDefaultVideoPayloads.add(new RtcPayloadImpl(120, "RTX", 90000, new HashMap<String, Object>(){{
                 put("apt", 100);

--- a/sdk/src/main/java/com/ericsson/research/owr/sdk/SessionDescriptions.java
+++ b/sdk/src/main/java/com/ericsson/research/owr/sdk/SessionDescriptions.java
@@ -50,12 +50,22 @@ public class SessionDescriptions {
         } catch (JSONException e) {
             throw new InvalidDescriptionException("jsep message has no type", e);
         }
+
         try {
             sdpStr = json.getString("sdp");
         } catch (JSONException e) {
             throw new InvalidDescriptionException("jsep message has no sdp", e);
         }
-        JSONObject sdp = SdpProcessor.sdpToJson(sdpStr);
+
+        JSONObject sdp;
+        if(json.has("sessionDescription")) {
+            try {
+                sdp = json.getJSONObject("sessionDescription");
+            } catch (JSONException e) {
+                throw new InvalidDescriptionException("invalid sessionDescription in jsep message", e);
+            }
+        }
+        else sdp = SdpProcessor.sdpToJson(sdpStr);
 
         SessionDescription.Type descriptionType;
         switch (type) {
@@ -317,6 +327,7 @@ public class SessionDescriptions {
 
     public static JSONObject toJsep(SessionDescription sessionDescription) {
         JSONObject json = new JSONObject();
+        JSONObject sdpJson = null;
         String type;
         String sdpStr;
 
@@ -332,7 +343,7 @@ public class SessionDescriptions {
         }
 
         try {
-            JSONObject sdpJson = sessionDescriptionToOwrJson(sessionDescription);
+            sdpJson = sessionDescriptionToOwrJson(sessionDescription);
             sdpStr = SdpProcessor.jsonToSdp(sdpJson);
         } catch (InvalidDescriptionException | JSONException e) {
             throw new IllegalArgumentException("json to sdp conversion failed: " + e.getMessage(), e);
@@ -340,6 +351,7 @@ public class SessionDescriptions {
 
         try {
             json.put("type", type);
+            json.put("sessionDescription", sdpJson);
             json.put("sdp", sdpStr);
             return json;
         } catch (JSONException e) {


### PR DESCRIPTION
Fixed session description and candidate messages handling so it is compatible with both raw format and JSON description format. 

EDIT: I made candidate and candidateDescription messages behave the same as sdp and sessionDescription messages because it seemed like the clean way to implement it. However, the example web client strangely requires nested candidate messages (i.e. candidate.candidate and candidate.sessionDescription), so I patched it in [paullouisageneau/openwebrtc-examples](https://github.com/paullouisageneau/openwebrtc-examples/tree/candidateDescription). This might not be desirable as it requires to patch other clients like iOS... What do you think ?
